### PR TITLE
fix title and dependencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cmp-path
+# cmp-doxygen
 
 nvim-cmp source for doxygen keywords.
 
@@ -7,7 +7,10 @@ nvim-cmp source for doxygen keywords.
 ```lua
   use {
     "paopaol/cmp-doxygen",
-    requires = "nvim-treesitter/nvim-treesitter",
+    requires = {
+      "nvim-treesitter/nvim-treesitter",
+      "nvim-treesitter/nvim-treesitter-textobjects"
+    }
   }
 ```
 


### PR DESCRIPTION
I got the error “module 'nvim-treesitter.textobjects.shared' not found”. After installing [nvim-treesitter/nvim-treesitter-textobjects](https://github.com/nvim-treesitter/nvim-treesitter-textobjects) it works.